### PR TITLE
feat: Atualizar .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ dkms.conf
 
 .vscode/
 output/
+
+conversor


### PR DESCRIPTION
Adicionar `conversor` no `.gitignore` para o executável na versão linux